### PR TITLE
App Install Location

### DIFF
--- a/AnotherMonitor/src/main/AndroidManifest.xml
+++ b/AnotherMonitor/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="org.anothermonitor"
+          android:installLocation="auto"
           android:versionCode="6"
           android:versionName="3.0.4">
 


### PR DESCRIPTION
The internal memory of my device is quite small, this PR should allow users to easily move the app to the microSD.

To allow the system to install your application on the external storage, modify your manifest file to include the android:installLocation attribute in the element, with a value of either "preferExternal" or "auto". (source: https://developer.android.com/guide/topics/data/install-location.html)
